### PR TITLE
Fix non-moderators seeing the ban dialog on user info pages.

### DIFF
--- a/templates/user_info.html
+++ b/templates/user_info.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {%- block content %}
-{%- if user is not none and user.is_moderator -%}
+{%- if user is not none and user.is_moderator() -%}
 <p>
 <form method=post action="{{ url_for('moderator_ban_user', user_id = id) }}">
 <input type=number name=days placeholder=days>


### PR DESCRIPTION
It's purely a UI bug, so it's not a security issue.